### PR TITLE
fix(ci): ship ci-config.yml with all compilers disabled by default

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -10,15 +10,15 @@
 # For full documentation, see docs/CI.md
 
 linux:
-  gcc-14: true       # System GCC (UBI 10)
-  gcc-15: true       # GCC Toolset 15 (gcc-toolset-15)
-  clang: true        # System Clang (UBI 10, version depends on minor release)
-  intel: true        # Intel ICX/ICPX (oneAPI, uses separate container image)
+  gcc-14: false       # System GCC (UBI 10)
+  gcc-15: false       # GCC Toolset 15 (gcc-toolset-15)
+  clang: false        # System Clang (UBI 10, version depends on minor release)
+  intel: false        # Intel ICX/ICPX (oneAPI, uses separate container image)
 
 macos:
-  llvm: true         # LLVM/Clang via setup-cpp (version set by CLANG_TIDY_VERSION)
-  gcc-14: true       # Homebrew GCC 14 (coverage skipped, issue #5)
+  llvm: false         # LLVM/Clang via setup-cpp (version set by CLANG_TIDY_VERSION)
+  gcc-14: false       # Homebrew GCC 14 (coverage skipped, issue #5)
 
 windows:
-  msvc: true         # Visual Studio 17 2022
-  llvm: true         # Clang-cl via LLVM (version set by CLANG_TIDY_VERSION)
+  msvc: false         # Visual Studio 17 2022
+  llvm: false         # Clang-cl via LLVM (version set by CLANG_TIDY_VERSION)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,16 @@ jobs:
       - id: config
         env:
           CLANG_TIDY_VERSION: ${{ env.CLANG_TIDY_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CONFIG=$(yq -o=json . .github/ci-config.yml)
+          # On the template repo itself, enable all compilers regardless of
+          # ci-config.yml (which ships with all false for derived repos).
+          IS_TEMPLATE=$(gh api repos/${{ github.repository }} --jq '.is_template // false' 2>/dev/null || echo "false")
+          if [ "$IS_TEMPLATE" = "true" ]; then
+            CONFIG='{"linux":{"gcc-14":true,"gcc-15":true,"clang":true,"intel":true},"macos":{"llvm":true,"gcc-14":true},"windows":{"msvc":true,"llvm":true}}'
+          else
+            CONFIG=$(yq -o=json . .github/ci-config.yml)
+          fi
 
           # --- Linux ---
           LINUX=$(echo "$CONFIG" | jq -c '[.linux | to_entries[] | select(.value == true) | .key]')

--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -113,13 +113,6 @@ jobs:
           mv include/myproject include/${{ env.NEW_SAFE_PROJECT }}
           cp ${{ env.TEMPLATES_PATH }}/README.md README.md
 
-      - name: Disable all CI compilers for derived repo
-        if: fromJson(steps.get_repo_meta.outputs.data).is_template == false
-        run: |
-          # Derived repos should start with all compilers disabled.
-          # Users enable only the compilers they need in .github/ci-config.yml
-          sed -i 's/: true/: false/g' .github/ci-config.yml
-
       - name: Print diff after replacement
         run: |
           # Exclude the README as that is checked separately!

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -4,20 +4,24 @@ The CI pipeline is configurable via `.github/ci-config.yml`. Users can
 toggle which compilers are tested on each platform without editing
 workflow files.
 
+All compilers are **disabled by default** in derived repos. Enable only
+the compilers your project needs. The template repo itself
+auto-enables all compilers via `is_template` detection.
+
 ## Configuration file
 
-Edit `.github/ci-config.yml` to enable or disable compilers:
+Edit `.github/ci-config.yml` to enable compilers for your project:
 
 ```yaml
 linux:
   gcc-14: true       # System GCC (UBI 10)
-  gcc-15: true       # GCC Toolset 15
+  gcc-15: false      # GCC Toolset 15
   clang: true        # System Clang (version depends on UBI minor release)
-  intel: true        # Intel ICX/ICPX (oneAPI)
+  intel: false       # Intel ICX/ICPX (oneAPI)
 
 macos:
   llvm: true         # LLVM/Clang via setup-cpp
-  gcc-14: true       # Homebrew GCC 14
+  gcc-14: false      # Homebrew GCC 14
 
 windows:
   msvc: true         # Visual Studio 17 2022


### PR DESCRIPTION
## Summary

- Ship `ci-config.yml` with all compilers set to `false`
- Template repo auto-enables all compilers via `is_template` API detection in setup job
- Remove Janitor sed step (no longer needed — config already ships disabled)
- Update docs/CI.md

This eliminates the race condition where CI and the Janitor triggered simultaneously on the first push of a derived repo, wasting CI resources on a full 36-job matrix.

## Test plan

- [ ] Template repo CI still runs all 36 jobs (is_template override works)
- [ ] Derived repo CI skips all platform jobs (config has all false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)